### PR TITLE
Re-tighten R-CMD-check error-on default (plan 7.6)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,4 +48,3 @@ jobs:
         with:
           upload-snapshots: true
           build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
-          error-on: '"error"'

--- a/dev/DEVELOPMENT_PLAN.md
+++ b/dev/DEVELOPMENT_PLAN.md
@@ -196,7 +196,7 @@ Tick boxes as items land.
 - [ ] **7.5 Update `README.Rmd` badges.** Replace the placeholder block
   with real R-CMD-check / lifecycle / CRAN-status badges. *(15 min)*
 
-- [ ] **7.6 Re-tighten R-CMD-check `error-on`.** Phase 1.3 set
+- [x] **7.6 Re-tighten R-CMD-check `error-on`.** Phase 1.3 set
   `error-on: '"error"'` in `.github/workflows/R-CMD-check.yaml` so the
   workflow could merge while Phase 2/3 cleanups landed. Once
   `devtools::check()` is 0W/0N, delete the line (default `"warning"`)


### PR DESCRIPTION
## Summary

- Revert `error-on: '"error"'` added in `042f265` to bridge Phase 1 → 2/3 cleanups. Default `"warning"` re-engages, so future regressions fail CI again.
- Plan item 7.6.

## Test plan

- [ ] CI matrix passes under the default gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)