### PR TITLE
Phase 4 + 5: tests, palmerpenguins vignette, render-dep hygiene

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,5 @@ TODO
 legacy
 ^README\.html$
 ^CITATION\.cff$
+^doc$
+^Meta$

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ data_raw/
 .Ruserdata
 README.html
 .Rprofile
+/doc/
+/Meta/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,6 +49,7 @@ Suggests:
     fontawesome,
     gt,
     knitr,
+    palmerpenguins,
     pkgdown,
     stringr,
     testthat

--- a/R/build_package.R
+++ b/R/build_package.R
@@ -326,6 +326,37 @@ build_roxygen <- function(type = "dataset", base_path = NULL, verbose = TRUE) {
   return(invisible(TRUE))
 }
 
+# Declare the packages the README templates (inst/templates/README.{Rmd,qmd})
+# need at render time in the user's package DESCRIPTION:Suggests, so the
+# README still knits on machines that don't happen to have all of them
+# installed. Skips any package already declared under any dep type, so
+# we never silently move an Import to Suggests.
+.add_readme_render_suggests <- function(base_path, verbose = TRUE) {
+  desc_path <- file.path(base_path, "DESCRIPTION")
+  if (!file.exists(desc_path)) return(invisible(character()))
+
+  render_deps <- c("desc", "dplyr", "readr", "gt", "fontawesome", "stringr", "here")
+
+  d <- desc::desc(file = desc_path)
+  existing <- d$get_deps()$package
+  to_add <- setdiff(render_deps, existing)
+
+  for (pkg in to_add) {
+    d$set_dep(pkg, type = "Suggests")
+  }
+
+  if (length(to_add) > 0) {
+    d$write()
+    if (verbose) {
+      cli::cli_alert_success(
+        "Added README render deps to {.path DESCRIPTION} Suggests: {.pkg {to_add}}"
+      )
+    }
+  }
+
+  invisible(to_add)
+}
+
 #' Build README from inst/templates/README.qmd
 #'
 #' Build README.md from the README.qmd template, incorporating package metadata.
@@ -345,6 +376,8 @@ build_readme <- function(
   base_path <- get_base_path(base_path)
   quarto_installed <- system("quarto --version", ignore.stderr = TRUE) == 0
   cli::cli_alert_info("Is Quarto installed: {quarto_installed}")
+
+  .add_readme_render_suggests(base_path, verbose = verbose)
 
   if (quarto && quarto_installed) {
     # Create README.qmd from template if it doesn't exist

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -9,6 +9,10 @@
 #' @param verbose Whether to show detailed messages (default: TRUE)
 #' @param overwrite Whether to overwrite existing files (default: FALSE)
 #' @return Invisibly returns a list with setup results
+#' @examples
+#' \dontrun{
+#' setup(base_path = "path/to/my-data-package")
+#' }
 #' @export
 setup <- function(
   raw_dir = "data_raw",
@@ -77,6 +81,10 @@ setup <- function(
 #' @param base_path Base path for the project
 #' @param verbose Whether to show detailed messages (default: TRUE)
 #' @return Invisibly returns a list of processed files
+#' @examples
+#' \dontrun{
+#' process(base_path = "path/to/my-data-package")
+#' }
 #' @export
 process <- function(
   raw_dir = NULL,
@@ -143,6 +151,20 @@ process <- function(
 #' @param overwrite Whether to overwrite existing metadata (default: FALSE)
 #' @param ... Additional arguments passed to collect_metadata
 #' @return List containing all metadata organized by category
+#' @examples
+#' \dontrun{
+#' # Interactive: walks you through prompts for title, authors, license, etc.
+#' collect(base_path = "path/to/my-data-package")
+#'
+#' # Non-interactive: supply every required field as a named argument.
+#' collect(
+#'   base_path = "path/to/my-data-package",
+#'   interactive = FALSE,
+#'   pkg_name = "mypkg",
+#'   title = "My Package",
+#'   description = "What this package contains."
+#' )
+#' }
 #' @export
 collect <- function(
   extended = FALSE,
@@ -217,6 +239,15 @@ collect <- function(
 #' @param verbose Whether to show detailed messages (default: TRUE)
 #' @param ... Additional arguments passed to gendict
 #' @return Data frame containing the dictionary
+#' @examples
+#' \dontrun{
+#' # Without an LLM: produces a dictionary skeleton with empty descriptions.
+#' generate(base_path = "path/to/my-data-package")
+#'
+#' # With an LLM: fills in descriptions via ellmer.
+#' chat <- ellmer::chat_openai(model = "gpt-4o-mini")
+#' generate(base_path = "path/to/my-data-package", chat = chat)
+#' }
 #' @export
 generate <- function(
   chat = NULL,
@@ -295,6 +326,10 @@ generate <- function(
 #' @param preview Whether to preview the site after building (default: TRUE)
 #' @param quarto Whether to use Quarto to build readme (default: FALSE)
 #' @return List with results from each build step
+#' @examples
+#' \dontrun{
+#' build(base_path = "path/to/my-data-package")
+#' }
 #' @export
 build <- function(
   base_path = NULL,
@@ -404,6 +439,15 @@ build <- function(
 #' @param base_path Base path for the project
 #' @param ... Additional arguments passed to collect() and generate() function
 #' @return List containing results from all pipeline steps
+#' @examples
+#' \dontrun{
+#' # Full pipeline in one call, prompting for metadata interactively.
+#' fairenough(base_path = "path/to/my-data-package")
+#'
+#' # With an LLM-backed chat for variable descriptions.
+#' chat <- ellmer::chat_openai(model = "gpt-4o-mini")
+#' fairenough(base_path = "path/to/my-data-package", chat = chat)
+#' }
 #' @export
 fairenough <- function(
   chat = NULL,

--- a/dev/DEVELOPMENT_PLAN.md
+++ b/dev/DEVELOPMENT_PLAN.md
@@ -128,11 +128,17 @@ Tick boxes as items land.
   under both `devtools::test()` and R CMD check. *(5 min — actual:
   ~45 min once the test-runner gap was discovered)*
 
-- [ ] **4.2 Add a fake `chat` mock** + skip patterns. Pattern: a small
+- [x] **4.2 Add a fake `chat` mock** + skip patterns. Pattern: a small
   stand-in object satisfying the `ellmer::chat` interface used in
   `gendict()`; `chat$chat()` returns canned strings. Add
   `testthat::skip_if(Sys.getenv("OPENAI_API_KEY") == "")` to any test
-  that talks to a real provider. *(1 hr)*
+  that talks to a real provider. Resolution: added `make_fake_chat()`
+  and `skip_without_openai()` to `tests/testthat/helpers-testing.R`.
+  Mock is a duck-typed list with `$chat(prompt)` returning a string
+  (sufficient for gendict's sequential path) and a `$calls()`
+  introspection method so tests can assert on what was sent. No
+  existing tests called a real provider, so the skip helper is staged
+  for use by future integration tests. *(1 hr)*
 
 - [ ] **4.3 Add `gendict` unit test** using the mock. Asserts the
   returned tibble shape, that variable names match input columns, and

--- a/dev/DEVELOPMENT_PLAN.md
+++ b/dev/DEVELOPMENT_PLAN.md
@@ -160,6 +160,19 @@ Tick boxes as items land.
   `setup`, `process`, `collect`, `generate`, `build`. Use `\dontrun{}`
   for anything filesystem-mutating. *(1 hr)*
 
+- [ ] **5.4 Populate the generated user package's `Suggests:` with
+  README render-time deps.** `setup_package()` calls
+  `usethis::create_package()` which produces a minimal `DESCRIPTION`.
+  The README templates copied in by `build_readme()`
+  (`inst/templates/README.{Rmd,qmd}`) require `desc`, `dplyr`, `readr`,
+  `gt`, `fontawesome`, `stringr`, and `here` at render time, but none
+  are declared in the new package's `DESCRIPTION`. Result: README
+  renders only on machines that happen to have all seven installed.
+  Add a step (in `setup_package()` or `build_readme()`) that writes
+  these to the user package's `Suggests:` via `desc::desc_set_dep()`.
+  Surfaced post-3.1 when reviewing the template's dependency story.
+  *(30 min)*
+
 ## Phase 6 — Refactors (non-blocking; big readability wins)
 
 - [ ] **6.1 Strip ~25 `cat("DEBUG: ...")` scaffolding lines** in

--- a/dev/DEVELOPMENT_PLAN.md
+++ b/dev/DEVELOPMENT_PLAN.md
@@ -162,16 +162,28 @@ Tick boxes as items land.
 
 ## Phase 5 — Vignette: palmerpenguins demo
 
-- [ ] **5.1 Create a vignette** demonstrating the full pipeline on
+- [x] **5.1 Create a vignette** demonstrating the full pipeline on
   penguins: `vignettes/palmerpenguins-demo.Rmd`. Walks through setup →
   process → collect → generate → build, ending with the resulting
   package layout. Use `eval = FALSE` for the `chat` step (or the mock
   from 4.2) so it does not need an API key in CI. **This replaces the
-  role of the deleted submodule.** *(3 hr)*
+  role of the deleted submodule.** Resolution: hybrid execution —
+  setup/process/collect/generate run live during knit, `build()` is
+  shown as `eval = FALSE` so the vignette stays under a few seconds.
+  Uses an inline 5-line duck-typed `chat` mock so no API key is ever
+  needed. `palmerpenguins` added to `Suggests:` (the only practical
+  way to get a real dataset into a CRAN vignette); the entire vignette
+  is `eval = FALSE` when the package isn't installed, with a one-line
+  fallback message. *(3 hr)*
 
-- [ ] **5.2 Resolve the `VignetteBuilder` warning.** Once 5.1 lands,
+- [x] **5.2 Resolve the `VignetteBuilder` warning.** Once 5.1 lands,
   `DESCRIPTION`'s `VignetteBuilder: knitr` is justified. Update
-  `inst/doc` handling in `.gitignore` if needed. *(15 min)*
+  `inst/doc` handling in `.gitignore` if needed. Resolution: nothing
+  to do for `VignetteBuilder: knitr` (already declared, `knitr`
+  already in `Suggests:`). `devtools::build_vignettes()` auto-added
+  `/doc/` and `/Meta/` to `.gitignore` and the matching `^doc$` /
+  `^Meta$` to `.Rbuildignore` when 5.1's vignette first built; the
+  pre-existing `inst/doc` entry is also kept. *(15 min)*
 
 - [ ] **5.3 Add `@examples` to public functions.** Minimum: `fairenough`,
   `setup`, `process`, `collect`, `generate`, `build`. Use `\dontrun{}`

--- a/dev/DEVELOPMENT_PLAN.md
+++ b/dev/DEVELOPMENT_PLAN.md
@@ -148,10 +148,17 @@ Tick boxes as items land.
   for every row; one prompt sent to the chat per input column
   (introspection via the mock's `$calls()` accessor). *(1 hr)*
 
-- [ ] **4.4 Add an end-to-end `fairenough()` test** on a tiny synthetic
+- [x] **4.4 Add an end-to-end `fairenough()` test** on a tiny synthetic
   CSV in `withr::local_tempdir()`. No `chat` arg → tests the no-LLM path.
   Assert the resulting directory has `DESCRIPTION`, `R/`, `data/`,
-  `inst/extdata/`. *(1.5 hr)*
+  `inst/extdata/`. Added `tests/testthat/test-fairenough-e2e.R`. To run
+  non-interactively the test passes `interactive = FALSE` and supplies
+  values for the required prompts (`pkg_name`, `title`, `description`)
+  via `fairenough()`'s `...`. Two hygiene measures: `skip_on_cran()`
+  because the test exercises `devtools::install` + `pkgdown::build_site`
+  (~minute), and `withr::local_libpaths()` so the generated test
+  package installs into a per-test temp library instead of leaking
+  into the user's R library. *(1.5 hr)*
 
 ## Phase 5 — Vignette: palmerpenguins demo
 

--- a/dev/DEVELOPMENT_PLAN.md
+++ b/dev/DEVELOPMENT_PLAN.md
@@ -185,9 +185,13 @@ Tick boxes as items land.
   `^Meta$` to `.Rbuildignore` when 5.1's vignette first built; the
   pre-existing `inst/doc` entry is also kept. *(15 min)*
 
-- [ ] **5.3 Add `@examples` to public functions.** Minimum: `fairenough`,
+- [x] **5.3 Add `@examples` to public functions.** Minimum: `fairenough`,
   `setup`, `process`, `collect`, `generate`, `build`. Use `\dontrun{}`
-  for anything filesystem-mutating. *(1 hr)*
+  for anything filesystem-mutating. All six wrappers in `R/wrappers.R`
+  now carry an `@examples` block wrapped in `\dontrun{}`. `collect`,
+  `generate`, and `fairenough` show both an interactive/default form
+  and a non-interactive / LLM-backed form so the docs match what
+  users actually need to write. *(1 hr)*
 
 - [ ] **5.4 Populate the generated user package's `Suggests:` with
   README render-time deps.** `setup_package()` calls

--- a/dev/DEVELOPMENT_PLAN.md
+++ b/dev/DEVELOPMENT_PLAN.md
@@ -140,9 +140,13 @@ Tick boxes as items land.
   existing tests called a real provider, so the skip helper is staged
   for use by future integration tests. *(1 hr)*
 
-- [ ] **4.3 Add `gendict` unit test** using the mock. Asserts the
+- [x] **4.3 Add `gendict` unit test** using the mock. Asserts the
   returned tibble shape, that variable names match input columns, and
-  the `description` column is non-empty. *(1 hr)*
+  the `description` column is non-empty. Four `test_that` blocks in
+  `tests/testthat/test-gendict.R`: tibble shape + columns; variable
+  column matches input names in order; description column non-empty
+  for every row; one prompt sent to the chat per input column
+  (introspection via the mock's `$calls()` accessor). *(1 hr)*
 
 - [ ] **4.4 Add an end-to-end `fairenough()` test** on a tiny synthetic
   CSV in `withr::local_tempdir()`. No `chat` arg → tests the no-LLM path.

--- a/dev/DEVELOPMENT_PLAN.md
+++ b/dev/DEVELOPMENT_PLAN.md
@@ -193,7 +193,7 @@ Tick boxes as items land.
   and a non-interactive / LLM-backed form so the docs match what
   users actually need to write. *(1 hr)*
 
-- [ ] **5.4 Populate the generated user package's `Suggests:` with
+- [x] **5.4 Populate the generated user package's `Suggests:` with
   README render-time deps.** `setup_package()` calls
   `usethis::create_package()` which produces a minimal `DESCRIPTION`.
   The README templates copied in by `build_readme()`
@@ -204,7 +204,11 @@ Tick boxes as items land.
   Add a step (in `setup_package()` or `build_readme()`) that writes
   these to the user package's `Suggests:` via `desc::desc_set_dep()`.
   Surfaced post-3.1 when reviewing the template's dependency story.
-  *(30 min)*
+  Resolution: added `.add_readme_render_suggests(base_path)` helper
+  in `R/build_package.R` and called it at the top of `build_readme()`.
+  It uses `desc::desc()` to inspect existing deps and only adds
+  packages not already declared under any type, so never moves an
+  Import to Suggests. *(30 min)*
 
 ## Phase 6 — Refactors (non-blocking; big readability wins)
 

--- a/man/build.Rd
+++ b/man/build.Rd
@@ -34,3 +34,8 @@ Wrapper function that runs all build functions in sequence.
 Generates roxygen docs, citation files, builds the package,
 creates README, and builds the website.
 }
+\examples{
+\dontrun{
+build(base_path = "path/to/my-data-package")
+}
+}

--- a/man/collect.Rd
+++ b/man/collect.Rd
@@ -36,3 +36,18 @@ List containing all metadata organized by category
 Wrapper function that collects comprehensive metadata for R data packages
 with clear step messaging.
 }
+\examples{
+\dontrun{
+# Interactive: walks you through prompts for title, authors, license, etc.
+collect(base_path = "path/to/my-data-package")
+
+# Non-interactive: supply every required field as a named argument.
+collect(
+  base_path = "path/to/my-data-package",
+  interactive = FALSE,
+  pkg_name = "mypkg",
+  title = "My Package",
+  description = "What this package contains."
+)
+}
+}

--- a/man/fairenough.Rd
+++ b/man/fairenough.Rd
@@ -32,3 +32,13 @@ from setup to final build in sequence. For more granular control,
 use individual wrapper functions: setup(), process(), collect(),
 generate(), and build().
 }
+\examples{
+\dontrun{
+# Full pipeline in one call, prompting for metadata interactively.
+fairenough(base_path = "path/to/my-data-package")
+
+# With an LLM-backed chat for variable descriptions.
+chat <- ellmer::chat_openai(model = "gpt-4o-mini")
+fairenough(base_path = "path/to/my-data-package", chat = chat)
+}
+}

--- a/man/generate.Rd
+++ b/man/generate.Rd
@@ -33,3 +33,13 @@ Data frame containing the dictionary
 Wrapper function that generates a data dictionary for all data files
 in the package with clear step messaging.
 }
+\examples{
+\dontrun{
+# Without an LLM: produces a dictionary skeleton with empty descriptions.
+generate(base_path = "path/to/my-data-package")
+
+# With an LLM: fills in descriptions via ellmer.
+chat <- ellmer::chat_openai(model = "gpt-4o-mini")
+generate(base_path = "path/to/my-data-package", chat = chat)
+}
+}

--- a/man/process.Rd
+++ b/man/process.Rd
@@ -30,3 +30,8 @@ Invisibly returns a list of processed files
 Wrapper function that processes all data files in the raw data directory
 with clear step messaging.
 }
+\examples{
+\dontrun{
+process(base_path = "path/to/my-data-package")
+}
+}

--- a/man/setup.Rd
+++ b/man/setup.Rd
@@ -30,3 +30,8 @@ Invisibly returns a list with setup results
 Wrapper function that initializes a fairenough data package project
 with clear step messaging.
 }
+\examples{
+\dontrun{
+setup(base_path = "path/to/my-data-package")
+}
+}

--- a/tests/testthat/helpers-testing.R
+++ b/tests/testthat/helpers-testing.R
@@ -31,3 +31,37 @@ cleanup_temp_dir <- function(temp_dir) {
     unlink(temp_dir, recursive = TRUE, force = TRUE)
   }
 }
+
+# Duck-typed stand-in for an ellmer chat object. gendict()'s sequential
+# path only calls chat$chat(prompt) and expects a character scalar back,
+# so a list with a $chat() closure is enough for testing without an
+# API key. `responses` cycles through canned replies; if NULL, a
+# deterministic templated string is returned. `$calls()` exposes the
+# prompts received so tests can assert on them.
+make_fake_chat <- function(responses = NULL) {
+  state <- new.env(parent = emptyenv())
+  state$i <- 0L
+  state$calls <- list()
+
+  list(
+    chat = function(prompt) {
+      state$i <- state$i + 1L
+      state$calls[[length(state$calls) + 1L]] <- as.character(prompt)
+      if (is.null(responses)) {
+        paste0("Mock description #", state$i)
+      } else {
+        responses[[((state$i - 1L) %% length(responses)) + 1L]]
+      }
+    },
+    calls = function() vapply(state$calls, identity, character(1))
+  )
+}
+
+# Skip pattern for tests that need a real LLM provider. Place at the
+# top of any test that calls a non-mocked ellmer chat.
+skip_without_openai <- function() {
+  testthat::skip_if(
+    identical(Sys.getenv("OPENAI_API_KEY"), ""),
+    "No OPENAI_API_KEY in environment"
+  )
+}

--- a/tests/testthat/test-fairenough-e2e.R
+++ b/tests/testthat/test-fairenough-e2e.R
@@ -1,0 +1,41 @@
+# End-to-end test of fairenough() on the no-LLM path.
+# Uses a tiny synthetic CSV and verifies that the orchestrator produces
+# the canonical R-package layout. No real LLM provider involved.
+
+test_that("fairenough() builds the package layout end-to-end without a chat", {
+  # Heavyweight: exercises the full pipeline including build_package's
+  # devtools::install and pkgdown::build_site. Skipped on CRAN so
+  # reviewers don't wait for the install/knit cycle.
+  testthat::skip_on_cran()
+
+  tmp <- withr::local_tempdir()
+
+  # Route devtools::install into a per-test temp library so the
+  # generated `testpkg` does not leak into the user's R library.
+  local_lib <- withr::local_tempdir()
+  withr::local_libpaths(local_lib, action = "prefix")
+
+  write.csv(
+    data.frame(x = 1:3, y = c("a", "b", "c"), stringsAsFactors = FALSE),
+    file.path(tmp, "tiny.csv"),
+    row.names = FALSE
+  )
+
+  suppressMessages(
+    fairenough(
+      base_path = tmp,
+      chat = NULL,
+      verbose = FALSE,
+      overwrite = TRUE,
+      interactive = FALSE,
+      pkg_name = "testpkg",
+      title = "Test Package",
+      description = "A test package for end-to-end testing."
+    )
+  )
+
+  expect_true(file.exists(file.path(tmp, "DESCRIPTION")))
+  expect_true(dir.exists(file.path(tmp, "R")))
+  expect_true(dir.exists(file.path(tmp, "data")))
+  expect_true(dir.exists(file.path(tmp, "inst", "extdata")))
+})

--- a/tests/testthat/test-gendict.R
+++ b/tests/testthat/test-gendict.R
@@ -1,0 +1,41 @@
+# Test gendict() against the fake chat mock from helpers-testing.R
+# These tests exercise the sequential code path (default) and never
+# hit a real LLM provider.
+
+test_that("gendict returns a tibble with variable + description columns", {
+  data <- data.frame(x = 1:3, y = c("a", "b", "c"), stringsAsFactors = FALSE)
+  chat <- make_fake_chat()
+
+  result <- suppressMessages(gendict(data, chat = chat))
+
+  expect_s3_class(result, "tbl_df")
+  expect_named(result, c("variable", "description"))
+  expect_equal(nrow(result), ncol(data))
+})
+
+test_that("gendict variable column matches input column names in order", {
+  data <- data.frame(alpha = 1:3, beta = 4:6, gamma = 7:9)
+  chat <- make_fake_chat()
+
+  result <- suppressMessages(gendict(data, chat = chat))
+
+  expect_equal(result$variable, names(data))
+})
+
+test_that("gendict description column is non-empty for every variable", {
+  data <- data.frame(x = 1:3, y = c("a", "b", "c"), stringsAsFactors = FALSE)
+  chat <- make_fake_chat()
+
+  result <- suppressMessages(gendict(data, chat = chat))
+
+  expect_true(all(nzchar(result$description)))
+})
+
+test_that("gendict sends one prompt per input column to the chat", {
+  data <- data.frame(a = 1:3, b = 4:6, c = 7:9)
+  chat <- make_fake_chat()
+
+  suppressMessages(gendict(data, chat = chat))
+
+  expect_length(chat$calls(), ncol(data))
+})

--- a/tests/testthat/test-pipeline.R
+++ b/tests/testthat/test-pipeline.R
@@ -42,20 +42,6 @@ test_that("process handles data files correctly", {
   expect_true(validation$all_required_passed)
 })
 
-test_that("collect updates DESCRIPTION", {
-  temp_dir <- tempfile()
-  dir.create(temp_dir)
-  on.exit(cleanup_temp_dir(temp_dir))
-  
-  suppressMessages(setup(base_path = temp_dir, verbose = FALSE, overwrite = TRUE))
-  
-  # Skip collect test in non-interactive mode (requires user input)
-  skip("collect() requires interactive input or mocking")
-  
-  # Check that DESCRIPTION was created/updated
-  expect_true(check_description_exists(temp_dir))
-})
-
 test_that("generate creates dictionary", {
   temp_dir <- tempfile()
   dir.create(temp_dir)

--- a/vignettes/palmerpenguins-demo.Rmd
+++ b/vignettes/palmerpenguins-demo.Rmd
@@ -1,0 +1,132 @@
+---
+title: "fairenough demo: turning palmerpenguins into a data package"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{fairenough demo: turning palmerpenguins into a data package}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+
+# This vignette uses palmerpenguins as input data. If it's not
+# installed, the whole vignette is skipped so we never block
+# package builds in environments without it.
+penguins_available <- requireNamespace("palmerpenguins", quietly = TRUE)
+knitr::opts_chunk$set(eval = penguins_available)
+```
+
+```{r needs-palmerpenguins, eval = !penguins_available, echo = FALSE, results = "asis"}
+cat("> This vignette requires the **palmerpenguins** package. Install it with `install.packages(\"palmerpenguins\")` and rebuild the vignette to see the demo.\n")
+```
+
+`fairenough` turns a tidy data file into a fully-documented R data package. This vignette walks through the full pipeline on the well-known Palmer penguins dataset, ending with the resulting package layout.
+
+We do every step in a throw-away project so nothing leaks into your real working directory.
+
+```{r workspace}
+library(fairenough)
+
+# Disposable working directory; cleaned up automatically.
+project <- withr::local_tempdir()
+
+# Drop a CSV of penguins into the project root — exactly what a user
+# would have when they start.
+write.csv(
+  palmerpenguins::penguins,
+  file.path(project, "penguins.csv"),
+  row.names = FALSE
+)
+```
+
+## Step 1: `setup()`
+
+`setup()` scaffolds the standard data-package layout (`R/`, `data/`, `data_raw/`, `inst/extdata/`), moves the input CSV into `data_raw/`, and configures `.gitignore`.
+
+```{r step-setup}
+setup(
+  base_path = project,
+  verbose = FALSE,
+  overwrite = TRUE
+)
+```
+
+## Step 2: `process()`
+
+`process()` reads everything in `data_raw/`, applies `janitor::clean_names()` to the column headers, and writes both a binary `.rda` (for `data()` access) and a tidy `.csv` (for download) per dataset.
+
+```{r step-process}
+process(base_path = project, verbose = FALSE)
+```
+
+## Step 3: `collect()`
+
+`collect()` gathers the metadata that lives in `DESCRIPTION` — title, description, authors, license, etc. Normally it walks the user through interactive prompts, but every field can also be supplied as a named argument, which is what we do here.
+
+```{r step-collect}
+collect(
+  base_path = project,
+  interactive = FALSE,
+  verbose = FALSE,
+  overwrite = TRUE,
+  pkg_name = "penguinpkg",
+  title = "Palmer Penguins as an R Data Package",
+  description = "Body size measurements for three penguin species observed on islands in the Palmer Archipelago.",
+  license = "mit",
+  authors = list(
+    list(
+      given = "Demo",
+      family = "Author",
+      email = "demo@example.org",
+      roles = c("aut", "cre")
+    )
+  )
+)
+```
+
+## Step 4: `generate()`
+
+`generate()` produces a per-variable dictionary at `inst/extdata/dictionary.csv`. Pass an `ellmer::chat()` object to fill the `description` column from an LLM; pass `NULL` (or no `chat`) to get the same dictionary with empty descriptions, which you can edit by hand.
+
+For a working vignette without an API key, we use a small stand-in object that duck-types the `chat` interface — the same trick the package's tests use.
+
+```{r step-generate}
+# Stand-in for an ellmer chat object. In real usage you'd write:
+#   chat <- ellmer::chat_openai(model = "gpt-4o-mini")
+fake_chat <- local({
+  i <- 0
+  list(chat = function(prompt) {
+    i <<- i + 1
+    sprintf("Demo description for variable #%d", i)
+  })
+})
+
+generate(
+  base_path = project,
+  chat = fake_chat,
+  verbose = FALSE,
+  overwrite = TRUE
+)
+```
+
+## Step 5: `build()` (not run here)
+
+`build()` is the final, heaviest step: it generates roxygen docs from the dictionary, writes `inst/CITATION` and `CITATION.cff`, runs `R CMD build` + `R CMD INSTALL`, knits the README, and builds the pkgdown site. We skip the call inside this vignette to keep the build fast, but the one-liner is just:
+
+```{r step-build, eval = FALSE}
+build(base_path = project, verbose = FALSE, preview = FALSE)
+```
+
+## The result
+
+Here is everything `fairenough` produced under `project/`:
+
+```{r tree}
+fs::dir_tree(project, recurse = TRUE)
+```
+
+That's a complete, installable R data package created from a single CSV — ready for `R CMD build`, GitHub, or CRAN.


### PR DESCRIPTION
## Summary

Covers all of Phase 4 (tests) and Phase 5 (vignette + docs) from `dev/DEVELOPMENT_PLAN.md`, building on the test-runner restoration that landed in #31.

- **4.2** Added `make_fake_chat()` and `skip_without_openai()` test helpers in `tests/testthat/helpers-testing.R`. The mock is a duck-typed list with `$chat(prompt) -> string` and a `$calls()` accessor for introspection — enough to drive gendict's sequential path without an API key.
- **4.3** Four `gendict()` unit tests using the mock: tibble shape, variable column matches input names, descriptions are non-empty, and one prompt is sent per input column (verified via `$calls()`).
- **4.4** End-to-end `fairenough()` test on a synthetic CSV in `withr::local_tempdir()`. Drives the full pipeline (setup → process → collect → generate → build) and asserts the resulting layout has `DESCRIPTION`, `R/`, `data/`, `inst/extdata/`. `skip_on_cran()` because it runs `devtools::install` + `pkgdown::build_site` (~minute); `withr::local_libpaths()` so the generated test package never leaks into the user's R library.
- **Test stub cleanup** Removed an always-skipped `collect()` placeholder test that pre-dated the mocking work. Its intended coverage is now in 4.4. Suite drops to 0 skips.
- **5.1 + 5.2** New vignette `vignettes/palmerpenguins-demo.Rmd`. Hybrid execution: setup/process/collect/generate run live during knit using an inline 5-line chat mock; `build()` is shown as `eval = FALSE`. Whole vignette is `eval = FALSE` when `palmerpenguins` isn't installed, so CRAN check farms without it still build cleanly. `palmerpenguins` added to `Suggests:`.
- **5.3** `@examples` blocks (all wrapped in `\dontrun{}`, since every wrapper mutates the filesystem) on `setup`, `process`, `collect`, `generate`, `build`, and `fairenough`. `collect`/`generate`/`fairenough` examples each show both an interactive and a non-interactive form.
- **5.4** New `.add_readme_render_suggests()` helper, called at the top of `build_readme()`. Adds `desc`, `dplyr`, `readr`, `gt`, `fontawesome`, `stringr`, `here` to the generated user package's `Suggests:` via `desc::desc_set_dep()` — only for packages not already declared under any type, so it never silently moves an Import to Suggests. Fixes the latent "README only renders on the author's machine" issue surfaced by the 3.1 template rewrite.

Local: R CMD check is 0E / 0W / 1 benign NOTE (network "unable to verify current time"); `devtools::test()` is 86 pass / 0 fail / 0 skip. CI will exercise the same suite (the runner has been live since #31).

After this lands, dev is clear for Phase 6 (refactors) and Phase 7 (pre-CRAN polish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)